### PR TITLE
Fix incorrect filename in hooks.server.ts documentation: 'loader.server.svelte.js' instead of 'loader.ssr.svelte.js'

### DIFF
--- a/src/content/docs/adapters/svelte.mdx
+++ b/src/content/docs/adapters/svelte.mdx
@@ -82,7 +82,7 @@ per request. You can set it up inside `hooks.server.{js,ts}`.
 
 ```js
 // hooks.server.js
-import { loadCatalog, loadIDs, key } from './locales/loader.ssr.svelte.js'
+import { loadCatalog, loadIDs, key } from './locales/loader.server.svelte.js'
 import { runWithLocale, loadLocales } from 'wuchale/load-utils/server'
 import { locales } from 'virtual:wuchale/locales'
 


### PR DESCRIPTION
This PR corrects the filename referenced in the documentation for `hooks.server.ts`. The import statement was incorrectly showing `'./locales/loader.ssr.svelte.js'`, but it should be `'./locales/loader.server.svelte.js'` to match the actual generated file.

## Changes Made
- Updated the import example in the documentation from `'./locales/loader.ssr.svelte.js'` to `'./locales/loader.server.svelte.js'`.

## Reason for Change
The incorrect filename was causing "Cannot find module" errors in user projects, as the actual file generated by wuchale is named `loader.server.svelte.js`, not `loader.ssr.svelte.js`. This fix ensures the documentation aligns with the implementation.

## Testing
- Verified that the corrected filename matches the file generated by wuchale in a test project.
- No functional code changes; this is purely a documentation update.

## Related Issues
- Fixes the module not found error reported in user projects using wuchale for internationalization.
- Closes #16

Labels: documentation, bug-fix, i18n